### PR TITLE
🤖 Auto-fix for CI/CD Failure (Fix #81)

### DIFF
--- a/AUTOMATED_FIX.md
+++ b/AUTOMATED_FIX.md
@@ -1,0 +1,16 @@
+# Automated Fix
+
+## Fix Applied:
+**Description:** To diagnose the actual pipeline failure, you must provide the correct, human-readable text logs from the failed step. The current data is unusable. Please follow these steps to retrieve the correct logs from the GitHub Actions run.
+
+**Steps:**
+1. Step 1: Navigate to the failed workflow run on GitHub at: https://github.com/chaitanyak175/Unknown/actions/runs/17192302962 (Note: 'Unknown' is a placeholder for your repository name).
+2. Step 2: Click on the specific job that failed (it will be marked with a red 'X').
+3. Step 3: In the left-hand pane, locate the step that failed. It will also be marked with a red 'X'. Click on it to expand the log output.
+4. Step 4: Copy the full text content from the expanded log window for the failed step. This will be the actual error message.
+5. Step 5: Provide the copied text log for a new analysis. Do not use the 'Download log archive' option unless you first unzip the file and then copy the text from the relevant log file within it.
+
+## Instructions:
+Please review the suggested changes and apply them manually if needed.
+
+Generated on: 2025-08-25T04:41:48.826722


### PR DESCRIPTION

## 🤖 Automated Fix

This PR contains an automated fix for a CI/CD failure.

### Fix Details:
**Description:** To diagnose the actual pipeline failure, you must provide the correct, human-readable text logs from the failed step. The current data is unusable. Please follow these steps to retrieve the correct logs from the GitHub Actions run.

**Steps:**
1. Step 1: Navigate to the failed workflow run on GitHub at: https://github.com/chaitanyak175/Unknown/actions/runs/17192302962 (Note: 'Unknown' is a placeholder for your repository name).
2. Step 2: Click on the specific job that failed (it will be marked with a red 'X').
3. Step 3: In the left-hand pane, locate the step that failed. It will also be marked with a red 'X'. Click on it to expand the log output.
4. Step 4: Copy the full text content from the expanded log window for the failed step. This will be the actual error message.
5. Step 5: Provide the copied text log for a new analysis. Do not use the 'Download log archive' option unless you first unzip the file and then copy the text from the relevant log file within it.

### Changes:
- Automatically generated fix based on failure analysis
- Applied by CI/CD Fixer Agent

### Review Required:
Please review the changes before merging to ensure they are correct.

---
*Generated by CI/CD Fixer Agent*
            