### PR TITLE
🤖 Auto-fix for CI/CD Failure (Fix #88)

### DIFF
--- a/AUTOMATED_FIX.md
+++ b/AUTOMATED_FIX.md
@@ -1,0 +1,24 @@
+# Automated Fix
+
+## Fix Applied:
+**Description:** The immediate problem is the inability to read the logs. The fix is to download the log archive directly from the CI/CD platform (likely GitHub Actions) and manually extract it to view the plain text logs. This will reveal the true cause of the pipeline failure.
+
+**Steps:**
+1. Navigate to the failed workflow run in your CI/CD platform's UI. Given the context, this is likely a GitHub Actions run.
+2. Locate the option to download the full log archive for the run. In GitHub Actions, this is typically found under a '...' menu on the job summary page, labeled 'Download log archive'.
+3. Save the downloaded ZIP file to your local machine.
+4. Use a standard utility to decompress the ZIP file (e.g., `unzip` command, or the built-in functionality in Windows/macOS).
+5. After extraction, you will find a directory structure containing individual text files for each job and step.
+6. Open the text files from the failed jobs (e.g., `1_lint-and-test (20).txt`, `docker-build/3_Build Docker image.txt`) to read the actual error messages in plain text and diagnose the underlying build or test failure.
+
+**Commands to run:**
+- `# On your local machine, after downloading the log archive (e.g., 'logs.zip')`
+- `unzip logs.zip -d extracted_logs`
+- `# Navigate into the directory and inspect the log files for errors`
+- `grep -i -r 'error' extracted_logs/`
+- `less extracted_logs/lint-and-test/3_Run_lint_and_tests.txt`
+
+## Instructions:
+Please review the suggested changes and apply them manually if needed.
+
+Generated on: 2025-08-25T10:04:53.113321


### PR DESCRIPTION

## 🤖 Automated Fix

This PR contains an automated fix for a CI/CD failure.

### Fix Details:
**Description:** The immediate problem is the inability to read the logs. The fix is to download the log archive directly from the CI/CD platform (likely GitHub Actions) and manually extract it to view the plain text logs. This will reveal the true cause of the pipeline failure.

**Steps:**
1. Navigate to the failed workflow run in your CI/CD platform's UI. Given the context, this is likely a GitHub Actions run.
2. Locate the option to download the full log archive for the run. In GitHub Actions, this is typically found under a '...' menu on the job summary page, labeled 'Download log archive'.
3. Save the downloaded ZIP file to your local machine.
4. Use a standard utility to decompress the ZIP file (e.g., `unzip` command, or the built-in functionality in Windows/macOS).
5. After extraction, you will find a directory structure containing individual text files for each job and step.
6. Open the text files from the failed jobs (e.g., `1_lint-and-test (20).txt`, `docker-build/3_Build Docker image.txt`) to read the actual error messages in plain text and diagnose the underlying build or test failure.

**Commands to run:**
- `# On your local machine, after downloading the log archive (e.g., 'logs.zip')`
- `unzip logs.zip -d extracted_logs`
- `# Navigate into the directory and inspect the log files for errors`
- `grep -i -r 'error' extracted_logs/`
- `less extracted_logs/lint-and-test/3_Run_lint_and_tests.txt`

### Changes:
- Automatically generated fix based on failure analysis
- Applied by CI/CD Fixer Agent

### Review Required:
Please review the changes before merging to ensure they are correct.

---
*Generated by CI/CD Fixer Agent*
            